### PR TITLE
Pulled new om_version key back out of model tree dict we weren't actu…

### DIFF
--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -189,7 +189,6 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
     tree_dict['type'] = 'subsystem'
     tree_dict['class'] = system.__class__.__name__
     tree_dict['expressions'] = None
-    tree_dict['om_version'] = openmdao_version
 
     if not isinstance(system, Group):
         tree_dict['subsystem_type'] = 'component'


### PR DESCRIPTION
…ally using it and it broke tests

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
