### PR TITLE
make python 3.7 the oldest in workflow, add ignore-vuln

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -74,8 +74,8 @@ jobs:
           # test oldest supported versions
           - NAME: Ubuntu Oldest
             OS: ubuntu-latest
-            PY: 3.8
-            NUMPY: 1.22
+            PY: 3.7
+            NUMPY: 1.21
             SCIPY: 1.7
             OPENMPI: '4.0'
             MPI4PY: '3.0'
@@ -283,7 +283,7 @@ jobs:
           echo "Scan environment for packages with known vulnerabilities"
           echo "(Temporarily ignoring PYSEC-2022-237, required by nbconvert)"
           echo "============================================================="
-          python -m pip_audit --ignore-vuln PYSEC-2022-237
+          python -m pip_audit --ignore-vuln PYSEC-2022-237 --ignore-vuln GHSA-fpfv-jqm9-f5jm
 
       - name: Run tests
         if: matrix.TESTS


### PR DESCRIPTION
### Summary

- Update GitHub workflow to test Python 3.7 as the oldest supported version.
- Ignore [vulnerability ](https://github.com/advisories/GHSA-fpfv-jqm9-f5jm)with NumPy 1.21 that NumPy developers have said is a [non-issue](https://github.com/numpy/numpy/issues/18993#issuecomment-1010427086)

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
